### PR TITLE
feat: Add GoPrompt logo to agent sidebar

### DIFF
--- a/components/AgentSidebar.tsx
+++ b/components/AgentSidebar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Agent } from '../types';
+import Logo from './Logo';
 
 interface AgentSidebarProps {
   agents: Agent[];
@@ -20,6 +21,9 @@ export const AgentSidebar: React.FC<AgentSidebarProps> = ({
 }) => {
   return (
     <aside className="w-80 bg-slate-900/70 backdrop-blur-md p-6 flex flex-col justify-between border-r border-slate-800 h-screen">
+      <div className="mb-8">
+        <Logo />
+      </div>
       <div>
         <div className="flex justify-between items-center mb-8">
           <h2 className="text-2xl font-semibold text-teal-400">Agents</h2>

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const Logo: React.FC = () => {
+  return (
+    <svg width="250" height="80" viewBox="0 0 250 80" xmlns="http://www.w3.org/2000/svg">
+      <g transform="translate(20, 30)" stroke="#20c997" stroke-width="3" fill="#20c997">
+        <circle cx="0" cy="10" r="4"/>
+        <circle cx="20" cy="0" r="4"/>
+        <circle cx="20" cy="20" r="4"/>
+        <line x1="0" y1="10" x2="20" y2="0"/>
+        <line x1="0" y1="10" x2="20" y2="20"/>
+      </g>
+      <text x="60" y="50" fontFamily="Open Sans, Segoe UI, sans-serif" fontSize="32" fontWeight="bold" fill="#E2E8F0">
+        Go<tspan fill="#20c997" fontWeight="normal">Prompt</tspan>
+      </text>
+    </svg>
+  );
+};
+
+export default Logo;


### PR DESCRIPTION
- I created a new Logo.tsx component with the provided SVG.
- I imported and displayed the Logo component at the top of the AgentSidebar.
- I adjusted the "Go" text color in the SVG to #E2E8F0 for better contrast against the dark sidebar background.